### PR TITLE
Copy Report with HTTP on remote hosts

### DIFF
--- a/src/app/bruno-list/bruno-list.component.css
+++ b/src/app/bruno-list/bruno-list.component.css
@@ -83,7 +83,7 @@ pre {
 .toast {
     background: lime;
     color: black;
-    font-weight: bolder;
+    font-weight: bold;
     padding: 12px 20px;
     position: fixed;
     top: 32px;
@@ -91,6 +91,20 @@ pre {
     border-radius: 6px;
     border: 3px solid;
     border-color: #3b9e48;
+    z-index: 1000;
+}
+
+.toast-error {
+    background: yellow;
+    color: black;
+    font-weight: bolder;
+    padding: 12px 20px;
+    position: fixed;
+    top: 32px;
+    right: 32px;
+    border-radius: 6px;
+    border: 3px solid;
+    border-color: red;
     z-index: 1000;
 }
 

--- a/src/app/bruno-list/bruno-list.component.html
+++ b/src/app/bruno-list/bruno-list.component.html
@@ -30,6 +30,10 @@
         <div *ngIf="toastVisible" class="toast">
             Copiato negli appunti!
         </div>
+        <div *ngIf="errorVisible" class="toast-error">
+            Non posso copiare negli appunti :-( 
+            <br>Usa CTRL+C
+        </div>
         <button (click)="copyReport()">Copia rapporto</button>
     </div>
 </div>

--- a/src/app/bruno-list/bruno-list.component.ts
+++ b/src/app/bruno-list/bruno-list.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { OrderService } from '../order.service';
 import { Subscription } from 'rxjs';
 import { ChatComponent } from '../chat/chat.component';
+import { ClipboardService } from '../clipboard.service';
 
 export interface Order {
   name: string;
@@ -21,6 +22,7 @@ export class BrunoListComponent {
   article: string = '';
   orders: Order[] = [];
   toastVisible = false;
+  errorVisible = false;
 
   // subscriptions for orders updates
   private newOrderSub?: Subscription;
@@ -28,7 +30,8 @@ export class BrunoListComponent {
   private resetSub?: Subscription;
   private initSub?: Subscription;
 
-  constructor(private orderService: OrderService) { }
+  constructor(private orderService: OrderService,
+    private clipboard: ClipboardService) { }
 
   ngOnInit() {
     this.newOrderSub = this.orderService.newOrder$.subscribe(order => {
@@ -107,9 +110,14 @@ export class BrunoListComponent {
 
   copyReport() {
     if (this.reportText) {
-      navigator.clipboard.writeText(this.reportText).then(() => {
-        this.toastVisible = true;
-        setTimeout(() => this.toastVisible = false, 3000);
+      this.clipboard.copyToClipboard(this.reportText).then((success) => {
+        if (success) {
+          this.toastVisible = true;
+          setTimeout(() => this.toastVisible = false, 3000);
+        } else {
+          this.errorVisible = true;
+          setTimeout(() => this.errorVisible = false, 3000);
+        }
       });
     }
   }

--- a/src/app/clipboard.service.spec.ts
+++ b/src/app/clipboard.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ClipboardService } from './clipboard.service';
+
+describe('ClipboardService', () => {
+  let service: ClipboardService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ClipboardService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/clipboard.service.ts
+++ b/src/app/clipboard.service.ts
@@ -1,0 +1,61 @@
+// clipboard.service.ts
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ClipboardService {
+
+  async copyToClipboard(text: string): Promise<boolean> {
+    try {
+      // Metodo 1: Clipboard API moderna (preferita)
+      if (this.isClipboardApiSupported()) {
+        await navigator.clipboard.writeText(text);
+        return true;
+      }
+      
+      // Metodo 2: Fallback con execCommand
+      return this.fallbackCopyTextToClipboard(text);
+    } catch (error) {
+      console.error('Errore durante la copia:', error);
+      
+      return this.fallbackCopyTextToClipboard(text);
+    }
+  }
+
+  private isClipboardApiSupported(): boolean {
+    return !!(navigator.clipboard && navigator.clipboard.writeText);
+  }
+
+  private fallbackCopyTextToClipboard(text: string): boolean {
+    try {
+      // Crea un elemento textarea temporaneo
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      
+      // Imposta stili per renderlo invisibile
+      textArea.style.position = 'fixed';
+      textArea.style.top = '-9999px';
+      textArea.style.left = '-9999px';
+      textArea.style.opacity = '0';
+      textArea.style.pointerEvents = 'none';
+      textArea.setAttribute('readonly', '');
+      
+      document.body.appendChild(textArea);
+      
+      // Seleziona e copia il testo
+      textArea.focus();
+      textArea.select();
+      textArea.setSelectionRange(0, text.length);
+      
+      // deprecated, a dirty little trick
+      const successful = document.execCommand('copy');
+      document.body.removeChild(textArea);
+      
+      return successful;
+    } catch (error) {
+      console.error('Fallback copy failed:', error);
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Fix issue #1 (https://github.com/midthegap/Brunos/issues/1). When clipboard API is not available, fallback to document.execCommand()